### PR TITLE
Handle snprintf Failures

### DIFF
--- a/ChopRender.cpp
+++ b/ChopRender.cpp
@@ -34,7 +34,7 @@ signed long ChopRender(UDINT pDest, UDINT _pTemplate, UDINT maxDestLength, UDINT
 	
 	if(pTemplate->compiled == 0) return CHOP_ERR_NOT_COMPILED;
 	
-	//Read Var
+	//Read Var 
 	for(i = 0; i < pTemplate->iSnippet; i++){		
 		// Append prefix
 		status = appendTo(pDest, maxDestLength, &offset, pTemplate->snippet[i].prefixStart, pTemplate->snippet[i].prefixLen);
@@ -54,7 +54,13 @@ signed long ChopRender(UDINT pDest, UDINT _pTemplate, UDINT maxDestLength, UDINT
 				if(pTemplate->snippet[i].flags[0] != '\0') { 
 					int numCharsWritten;
 					numCharsWritten = snprintf((char*)(pDest+offset), (maxDestLength-offset), pTemplate->snippet[i].flags, (char*)pTemplate->snippet[i].pv.address);
-					offset+= min(numCharsWritten, (maxDestLength-offset));
+					if (numCharsWritten < 0) {
+						numCharsWritten = 0;
+						status = CHOP_ERR_INTERNAL;	
+					}
+					else {
+						offset+= min(numCharsWritten, (maxDestLength-offset));	
+					}
 				}
 				else {
 					// String could be longer than sizeof pv.value 


### PR DESCRIPTION
## What
This feature will handle the negative value returned by snprintf when the buffer size provided is not large enough to handle the entire formatted string.

## Why

There are some indications that Chopper could be causing page faults, & this is something that theoretically could go wrong in Chopper.

I could not get the snprintf to produce a negative value using Chopper's API in sim, but this addition will catch that error if it arises.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204926742161031